### PR TITLE
fix(security): validate marketplace repo name before install/open

### DIFF
--- a/bin/manager.sh
+++ b/bin/manager.sh
@@ -742,9 +742,13 @@ do_open_repo() {
 # ── marketplace view ─────────────────────────────────────────────────────────
 
 # Sets m_name m_stars m_desc from one marketplace TSV row.
+# m_name feeds `run_mut plugin install "$m_name"` and a URL open below, so a
+# malicious/crafted GitHub result must not reach either as anything but a
+# plain owner/repo[/subdir] slug.
 split_mrow() {
   local IFS=$'\t'
   read -r m_name m_stars m_desc <<< "$1"
+  [[ "$m_name" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(/[A-Za-z0-9_.-]+)?$ ]] || m_name=""
 }
 
 market_url() {


### PR DESCRIPTION
## Problem

`split_mrow()` parses `m_name` (the repo slug) straight out of the GitHub search API response with no shape validation. That value later reaches:

- `run_mut plugin install "$m_name"`
- `open_url "https://github.com/$m_name"`

Only the search query (`m_query`) gets URL-encoded before use — the repo name returned by GitHub never does. A crafted repo name surfaced in marketplace search results (e.g. containing shell metacharacters or unexpected path segments) could inject into the install/open call rather than being treated as inert display text.

## Fix

Validate `m_name` once, at the single point every marketplace row passes through (`split_mrow`), rather than patching each call site separately. Anything that isn't a plain `owner/repo[/subdir]` slug is dropped to an empty string, so downstream calls fail closed instead of passing through untrusted data.

```bash
[[ "$m_name" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(/[A-Za-z0-9_.-]+)?$ ]] || m_name=""
```

## Testing

- `bash -n bin/manager.sh` — syntax clean
- Manual check: a normal `owner/repo` and `owner/repo/subdir` row parse unchanged; a row with shell metacharacters in the name comes out empty and is rejected downstream instead of reaching `plugin install` or `open_url`.

No behavior change for well-formed marketplace results.